### PR TITLE
イビルハッカーにオプションを追加

### DIFF
--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -702,6 +702,9 @@ public class CustomOptionHolder
     public static CustomOption EvilHackerCanMoveWhenUsesAdmin;
     public static CustomOption EvilHackerMadmateSetting;
     public static CustomOption EvilHackerButtonCooldown;
+    public static CustomOption EvilHackerHasEnhancedAdmin;
+    public static CustomOption EvilHackerCanSeeImpostorPositions;
+    public static CustomOption EvilHackerCanSeeDeadBodyPositions;
 
     public static CustomRoleOption SecretlyKillerOption;
     public static CustomOption SecretlyKillerPlayerCount;
@@ -1089,6 +1092,9 @@ public class CustomOptionHolder
         EvilHackerCanMoveWhenUsesAdmin = Create(200302, false, CustomOptionType.Impostor, "CanMoveWhenUsesAdmin", false, EvilHackerOption);
         EvilHackerMadmateSetting = Create(200304, false, CustomOptionType.Impostor, "CreateMadmateSetting", false, EvilHackerOption);
         EvilHackerButtonCooldown = Create(200305, false, CustomOptionType.Impostor, "CreateMadmateButtonCooldownSetting", 30f, 0f, 60f, 2.5f, EvilHackerMadmateSetting);
+        EvilHackerHasEnhancedAdmin = Create(200306, false, CustomOptionType.Impostor, "EvilHackerHasEnhancedAdmin", true, EvilHackerOption);
+        EvilHackerCanSeeImpostorPositions = Create(200307, false, CustomOptionType.Impostor, "EvilHackerCanSeeImpostorPositions", true, EvilHackerHasEnhancedAdmin);
+        EvilHackerCanSeeDeadBodyPositions = Create(200308, false, CustomOptionType.Impostor, "EvilHackerCanSeeDeadBodyPositions", true, EvilHackerHasEnhancedAdmin);
 
         EvilSeer.CustomOptionData.SetupCustomOptions();
 

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -706,6 +706,7 @@ public class CustomOptionHolder
     public static CustomOption EvilHackerCanSeeImpostorPositions;
     public static CustomOption EvilHackerCanSeeDeadBodyPositions;
     public static CustomOption EvilHackerCanUseAdminDuringMeeting;
+    public static CustomOption EvilHackerSabotageMapShowsAdmin;
 
     public static CustomRoleOption SecretlyKillerOption;
     public static CustomOption SecretlyKillerPlayerCount;
@@ -1097,6 +1098,7 @@ public class CustomOptionHolder
         EvilHackerCanSeeImpostorPositions = Create(200307, false, CustomOptionType.Impostor, "EvilHackerCanSeeImpostorPositions", true, EvilHackerHasEnhancedAdmin);
         EvilHackerCanSeeDeadBodyPositions = Create(200308, false, CustomOptionType.Impostor, "EvilHackerCanSeeDeadBodyPositions", true, EvilHackerHasEnhancedAdmin);
         EvilHackerCanUseAdminDuringMeeting = Create(200309, false, CustomOptionType.Impostor, "EvilHackerCanUseAdminDuringMeeting", true, EvilHackerOption);
+        EvilHackerSabotageMapShowsAdmin = Create(200310, false, CustomOptionType.Impostor, "EvilHackerSabotageMapShowsAdmin", true, EvilHackerOption);
 
         EvilSeer.CustomOptionData.SetupCustomOptions();
 

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -705,6 +705,7 @@ public class CustomOptionHolder
     public static CustomOption EvilHackerHasEnhancedAdmin;
     public static CustomOption EvilHackerCanSeeImpostorPositions;
     public static CustomOption EvilHackerCanSeeDeadBodyPositions;
+    public static CustomOption EvilHackerCanUseAdminDuringMeeting;
 
     public static CustomRoleOption SecretlyKillerOption;
     public static CustomOption SecretlyKillerPlayerCount;
@@ -1095,6 +1096,7 @@ public class CustomOptionHolder
         EvilHackerHasEnhancedAdmin = Create(200306, false, CustomOptionType.Impostor, "EvilHackerHasEnhancedAdmin", true, EvilHackerOption);
         EvilHackerCanSeeImpostorPositions = Create(200307, false, CustomOptionType.Impostor, "EvilHackerCanSeeImpostorPositions", true, EvilHackerHasEnhancedAdmin);
         EvilHackerCanSeeDeadBodyPositions = Create(200308, false, CustomOptionType.Impostor, "EvilHackerCanSeeDeadBodyPositions", true, EvilHackerHasEnhancedAdmin);
+        EvilHackerCanUseAdminDuringMeeting = Create(200309, false, CustomOptionType.Impostor, "EvilHackerCanUseAdminDuringMeeting", true, EvilHackerOption);
 
         EvilSeer.CustomOptionData.SetupCustomOptions();
 

--- a/SuperNewRoles/Patches/MapPatch.cs
+++ b/SuperNewRoles/Patches/MapPatch.cs
@@ -29,4 +29,26 @@ public static class MapBehaviourShowPatch
             opts.Mode = MapOptions.Modes.CountOverlay;
         }
     }
+    public static void Postfix(MapBehaviour __instance, [HarmonyArgument(0)] MapOptions opts)
+    {
+        if (!__instance.IsOpen)
+        {
+            return;
+        }
+        // サボタージュマップにアドミンを表示する
+        if (CachedPlayer.LocalPlayer.PlayerControl.IsRole(RoleId.EvilHacker) && RoleClass.EvilHacker.SabotageMapShowsAdmin && !MeetingHud.Instance && opts.Mode == MapOptions.Modes.Sabotage)
+        {
+            RoleClass.EvilHacker.IsMyAdmin = true;
+            __instance.countOverlay.gameObject.SetActive(true);
+            __instance.countOverlay.SetOptions(true, true);
+            __instance.countOverlayAllowsMovement = true;
+            __instance.taskOverlay.Hide();
+            __instance.HerePoint.enabled = true;
+            PlayerControl.LocalPlayer.SetPlayerMaterialColors(__instance.HerePoint);
+            __instance.ColorControl.SetColor(Palette.ImpostorRed);
+            // アドミンがサボタージュとドア閉めのボタンに隠れないようにする
+            // ボタンより手前
+            __instance.countOverlay.transform.SetLocalZ(-3f);
+        }
+    }
 }

--- a/SuperNewRoles/Patches/MapPatch.cs
+++ b/SuperNewRoles/Patches/MapPatch.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using SuperNewRoles.Roles;
 
 namespace SuperNewRoles.Patches;
 
@@ -13,5 +14,19 @@ class MapBehaviorGetIsOpenStoppedPatch
             return false;
         }
         return true;
+    }
+}
+
+[HarmonyPatch(typeof(MapBehaviour), nameof(MapBehaviour.Show))]
+public static class MapBehaviourShowPatch
+{
+    public static void Prefix([HarmonyArgument(0)] MapOptions opts)
+    {
+        // 会議中にマップを開くとアドミンを見ることができる
+        if (CachedPlayer.LocalPlayer.PlayerControl.IsRole(RoleId.EvilHacker) && RoleClass.EvilHacker.CanUseAdminDuringMeeting && MeetingHud.Instance && opts.Mode == MapOptions.Modes.Normal)
+        {
+            RoleClass.EvilHacker.IsMyAdmin = true;
+            opts.Mode = MapOptions.Modes.CountOverlay;
+        }
     }
 }

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1007,6 +1007,9 @@ EvilHackerTitle1,Hack to Win!,ハッキングして勝利しよう,黑入飞船�
 CanMoveWhenUsesAdmin,Can be moved while using Admin,アドミン使用中に移動できる,可以在观看地图时移动,可以在觀看管理員地圖時移動
 CreateMadmateSetting,Can Make a Madmate,マッドメイトを作れる,可以把一名玩家变成叛徒,可以把一名玩家變成叛徒
 CreateMadmateButtonCooldownSetting,Setting the cooldown for the [Drive Mad] ability.,[狂わせる]能力のクールタイムの設定,[洗脑]技能冷却设置,洗腦能力的冷卻時間
+EvilHackerHasEnhancedAdmin,Has Enhanced Admin,強化版アドミンを持つ
+EvilHackerCanSeeImpostorPositions,Can See Impostor Positions,インポスターの位置がわかる
+EvilHackerCanSeeDeadBodyPositions,Can See Dead-Body Positions,死体の位置がわかる
 CreateMadmateButton,Drive Mad,狂わせる,洗脑,洗腦
 PositionSwapperName,Position Swapper,ポジションスワッパー,念动使,交換使
 PositionSwapperTitle1,Let's Swap crewmates.,位置交換で困惑させろ,移形换影迷惑他人,交換位置使他人迷惑

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1010,6 +1010,7 @@ CreateMadmateButtonCooldownSetting,Setting the cooldown for the [Drive Mad] abil
 EvilHackerHasEnhancedAdmin,Has Enhanced Admin,強化版アドミンを持つ
 EvilHackerCanSeeImpostorPositions,Can See Impostor Positions,インポスターの位置がわかる
 EvilHackerCanSeeDeadBodyPositions,Can See Dead-Body Positions,死体の位置がわかる
+EvilHackerCanUseAdminDuringMeeting,Can Use Admin During Meeting,会議中にアドミンを使用できる
 CreateMadmateButton,Drive Mad,狂わせる,洗脑,洗腦
 PositionSwapperName,Position Swapper,ポジションスワッパー,念动使,交換使
 PositionSwapperTitle1,Let's Swap crewmates.,位置交換で困惑させろ,移形换影迷惑他人,交換位置使他人迷惑

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1011,6 +1011,7 @@ EvilHackerHasEnhancedAdmin,Has Enhanced Admin,強化版アドミンを持つ
 EvilHackerCanSeeImpostorPositions,Can See Impostor Positions,インポスターの位置がわかる
 EvilHackerCanSeeDeadBodyPositions,Can See Dead-Body Positions,死体の位置がわかる
 EvilHackerCanUseAdminDuringMeeting,Can Use Admin During Meeting,会議中にアドミンを使用できる
+EvilHackerSabotageMapShowsAdmin,Sabotage Map Shows Admin,サボタージュマップにもアドミンを表示する
 CreateMadmateButton,Drive Mad,狂わせる,洗脑,洗腦
 PositionSwapperName,Position Swapper,ポジションスワッパー,念动使,交換使
 PositionSwapperTitle1,Let's Swap crewmates.,位置交換で困惑させろ,移形换影迷惑他人,交換位置使他人迷惑

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -2038,6 +2038,7 @@ public static class RoleClass
         public static bool CanSeeImpostorPositions;
         /// <summary>アドミン上で死体のマークが青く見えるかどうか</summary>
         public static bool CanSeeDeadBodyPositions;
+        public static bool CanUseAdminDuringMeeting;
         public static bool IsMyAdmin;
         public static Sprite GetCreateMadmateButtonSprite() => ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.CreateMadmateButton.png", 115f);
 
@@ -2057,6 +2058,7 @@ public static class RoleClass
             var hasEnhancedAdmin = CustomOptionHolder.EvilHackerHasEnhancedAdmin.GetBool();
             CanSeeImpostorPositions = hasEnhancedAdmin && CustomOptionHolder.EvilHackerCanSeeImpostorPositions.GetBool();
             CanSeeDeadBodyPositions = hasEnhancedAdmin && CustomOptionHolder.EvilHackerCanSeeDeadBodyPositions.GetBool();
+            CanUseAdminDuringMeeting = CustomOptionHolder.EvilHackerCanUseAdminDuringMeeting.GetBool();
             IsMyAdmin = false;
             Cooldown = CustomOptionHolder.EvilHackerButtonCooldown.GetFloat();
         }

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -2039,6 +2039,8 @@ public static class RoleClass
         /// <summary>アドミン上で死体のマークが青く見えるかどうか</summary>
         public static bool CanSeeDeadBodyPositions;
         public static bool CanUseAdminDuringMeeting;
+        /// <summary>サボタージュマップにアドミンが表示されるかどうか</summary>
+        public static bool SabotageMapShowsAdmin;
         public static bool IsMyAdmin;
         public static Sprite GetCreateMadmateButtonSprite() => ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.CreateMadmateButton.png", 115f);
 
@@ -2059,6 +2061,7 @@ public static class RoleClass
             CanSeeImpostorPositions = hasEnhancedAdmin && CustomOptionHolder.EvilHackerCanSeeImpostorPositions.GetBool();
             CanSeeDeadBodyPositions = hasEnhancedAdmin && CustomOptionHolder.EvilHackerCanSeeDeadBodyPositions.GetBool();
             CanUseAdminDuringMeeting = CustomOptionHolder.EvilHackerCanUseAdminDuringMeeting.GetBool();
+            SabotageMapShowsAdmin = CustomOptionHolder.EvilHackerSabotageMapShowsAdmin.GetBool();
             IsMyAdmin = false;
             Cooldown = CustomOptionHolder.EvilHackerButtonCooldown.GetFloat();
         }

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -2034,6 +2034,10 @@ public static class RoleClass
         public static Color32 color = ImpostorRed;
         public static bool IsCreateMadmate;
         public static float Cooldown;
+        /// <summary>アドミン上でインポスターのマークが赤く見えるかどうか</summary>
+        public static bool CanSeeImpostorPositions;
+        /// <summary>アドミン上で死体のマークが青く見えるかどうか</summary>
+        public static bool CanSeeDeadBodyPositions;
         public static bool IsMyAdmin;
         public static Sprite GetCreateMadmateButtonSprite() => ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.CreateMadmateButton.png", 115f);
 
@@ -2050,6 +2054,9 @@ public static class RoleClass
         {
             EvilHackerPlayer = new();
             IsCreateMadmate = CustomOptionHolder.EvilHackerMadmateSetting.GetBool();
+            var hasEnhancedAdmin = CustomOptionHolder.EvilHackerHasEnhancedAdmin.GetBool();
+            CanSeeImpostorPositions = hasEnhancedAdmin && CustomOptionHolder.EvilHackerCanSeeImpostorPositions.GetBool();
+            CanSeeDeadBodyPositions = hasEnhancedAdmin && CustomOptionHolder.EvilHackerCanSeeDeadBodyPositions.GetBool();
             IsMyAdmin = false;
             Cooldown = CustomOptionHolder.EvilHackerButtonCooldown.GetFloat();
         }


### PR DESCRIPTION
イビルハッカーのアドミンを強化するオプションを追加しました
全てbool型オプションでデフォルトtrueです
GMH版イビルハッカーを強く意識しています(コードは使ってません)
色分けの都合上，アドミンのアイコンのデフォルト色を黄色に変更しています

|オプション名|説明|
|-|:-:|
|強化版アドミンを持つ||
|┣インポスターの位置がわかる|アドミン上でインポスターのアイコンが赤くなる|
|┗死体の位置がわかる|同様にグレーになる|
|会議中にアドミンを使用できる|会議中にマップを開くとアドミンが開く|
|サボタージュマップにもアドミンを表示する|サボタージュマップを開くと，アドミンが重なって表示される|

# スクリーンショット

強化版アドミン 左からインポスターの赤アイコン，死体のグレーアイコン，通常の黄色アイコン
![image](https://github.com/SuperNewRoles/SuperNewRoles/assets/86903430/c3060920-14fe-42f5-a425-1951d825b2d9)

会議中にアドミンを使用できる
![image](https://github.com/SuperNewRoles/SuperNewRoles/assets/86903430/bfa2288d-5c7e-47b8-9f62-e3e723c0131c)

サボタージュマップに表示されるアドミン
![image](https://github.com/SuperNewRoles/SuperNewRoles/assets/86903430/b0e9a288-ef6d-41cb-8ccb-82386e3c9f12)

通常のアドミンアイコンは黄色に変更
![image](https://github.com/SuperNewRoles/SuperNewRoles/assets/86903430/abf4f660-69c9-4db5-a7ac-43094b5c7e6e)

