### PR TITLE
editorconfigの改行コードをCRLFからLFに変更

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*.cs]
 indent_style = space
 indent_size = 4
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = false


### PR DESCRIPTION
コイツのせいで #1276 の差分が膨れ上がって小一時間溶かしました
見たところ実態としてもLFが使われているようなのでこれで問題ないかと思います
