### PR TITLE
エアシップ昇降機右の影を改変するオプションを追加

### DIFF
--- a/SuperNewRoles/MapCustoms/MapCustom.cs
+++ b/SuperNewRoles/MapCustoms/MapCustom.cs
@@ -38,6 +38,12 @@ class MapCustom
     public static CustomOption AddWireTask;
     public static CustomOption AntiTaskOverWall;
     internal static CustomOption ShuffleElectricalDoors;
+    /// <summary>昇降機右の上下の影を変更する設定</summary>
+    public static CustomOption ModifyGapRoomOneWayShadow;
+    /// <summary>インポスターが下から上を見ることができる設定</summary>
+    public static CustomOption GapRoomShadowIgnoresImpostors;
+    /// <summary>非インポスターが上から下を見ることができない設定</summary>
+    public static CustomOption DisableGapRoomShadowForNonImpostor;
 
     /*===============アガルタ===============*/
     public static CustomOption AgarthaSetting;
@@ -76,6 +82,9 @@ class MapCustom
         AddWireTask = Create(103207, false, CustomOptionType.Generic, "AddWireTaskSetting", false, AirshipSetting);
         AntiTaskOverWall = Create(103208, false, CustomOptionType.Generic, "AntiTaskOverWallSetting", false, AirshipSetting);
         ShuffleElectricalDoors = Create(103209, false, CustomOptionType.Generic, "ShuffleElectricalDoorsSetting", false, AirshipSetting);
+        ModifyGapRoomOneWayShadow = Create(103210, false, CustomOptionType.Generic, "ModifyGapRoomOneWayShadow", false, AirshipSetting);
+        GapRoomShadowIgnoresImpostors = Create(103211, false, CustomOptionType.Generic, "GapRoomShadowIgnoresImpostors", true, ModifyGapRoomOneWayShadow);
+        DisableGapRoomShadowForNonImpostor = Create(103212, false, CustomOptionType.Generic, "DisableGapRoomShadowForNonImpostor", true, ModifyGapRoomOneWayShadow);
 
         /*===============アガルタ===============*/
         AgarthaSetting = Create(103300, false, CustomOptionType.Generic, "<color=#a67646>Agartha</color>", false, MapCustomOption);

--- a/SuperNewRoles/Patches/IntroPatch.cs
+++ b/SuperNewRoles/Patches/IntroPatch.cs
@@ -348,7 +348,7 @@ public class IntroPatch
         string ImpostorText = __instance.ImpostorText.text;
         if (ModeHandler.IsMode(ModeId.Default, ModeId.SuperHostRoles))
         {
-            if (PlayerControl.LocalPlayer.IsNeutral() && !PlayerControl.LocalPlayer.IsRole(RoleId.GM,RoleId.Pokerface))
+            if (PlayerControl.LocalPlayer.IsNeutral() && !PlayerControl.LocalPlayer.IsRole(RoleId.GM, RoleId.Pokerface))
             {
                 IntroData Intro = IntroData.GetIntroData(PlayerControl.LocalPlayer.GetRole(), PlayerControl.LocalPlayer);
                 TeamTitle = ModTranslation.GetString("Neutral");

--- a/SuperNewRoles/Patches/IntroPatch.cs
+++ b/SuperNewRoles/Patches/IntroPatch.cs
@@ -3,6 +3,7 @@ using AmongUs.GameOptions;
 using BepInEx.Unity.IL2CPP.Utils.Collections;
 using HarmonyLib;
 using SuperNewRoles.Buttons;
+using SuperNewRoles.MapCustoms;
 using SuperNewRoles.Mode;
 using SuperNewRoles.Replay;
 using SuperNewRoles.Roles;
@@ -167,6 +168,25 @@ public class IntroPatch
                     RoleClass.Hitman.cooldownText.alignment = TMPro.TextAlignmentOptions.Center;
                     RoleClass.Hitman.cooldownText.transform.localPosition = bottomLeft + new Vector3(0f, -1f, -1f);
                     RoleClass.Hitman.cooldownText.gameObject.SetActive(true);
+                }
+            }
+        }
+        public static void Postfix()
+        {
+            // 昇降右の影
+            if (MapCustomHandler.IsMapCustom(MapCustomHandler.MapCustomId.Airship) && MapCustom.ModifyGapRoomOneWayShadow.GetBool() && ShipStatus.Instance.FastRooms.TryGetValue(SystemTypes.GapRoom, out var gapRoom))
+            {
+                var gapRoomShadow = gapRoom.GetComponentInChildren<OneWayShadows>();
+                var amImpostorLight = PlayerControl.LocalPlayer.IsImpostor() || PlayerControl.LocalPlayer.IsImpostorLight();
+                if (MapCustom.GapRoomShadowIgnoresImpostors.GetBool() && amImpostorLight)
+                {
+                    // オブジェクトを非アクティブにすると影判定自体が消えるのでどちらからでも見通せる
+                    gapRoomShadow.gameObject.SetActive(false);
+                }
+                else if (MapCustom.DisableGapRoomShadowForNonImpostor.GetBool() && !amImpostorLight)
+                {
+                    // OneWayShadowsを無効にしても影判定は残るので普通の壁のような双方向の影になる
+                    gapRoomShadow.enabled = false;
                 }
             }
         }

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -234,6 +234,9 @@ OnlyImpostorGhostSeeRole,Impostors display the roles of other players.,インポ
 CanGhostSeeVote,After death，everyone's voting address can be confirmed.,死亡者が全員の投票先を確認できる,死亡玩家能确认所有玩家的职业,死亡玩家能確認所有玩家的投票
 AntiTaskOverWallSetting,Cannot tasks over the wall.,壁越しにタスクをできない,禁止隔墙做任务,禁止隔牆做任務
 ShuffleElectricalDoorsSetting,Shuffle electrical doors after meeting,会議後に電気室のドアをシャッフルする,飞艇地图配电室门的开关在会议后重新分配,AirShip地圖配電室門的開關會在會議結束後重新配置
+ModifyGapRoomOneWayShadow,Modify GapRoom One-Way Shadow,昇降機の上下の影を変更する
+GapRoomShadowIgnoresImpostors,Impostors Can See Through from the Lower,インポスターが下から上を見ることができる
+DisableGapRoomShadowForNonImpostor,Only Impostors Can See Through from the Upper,インポスター以外が上から下を見られなくする
 
 # Modes
 ModeSetting,Mode Setting,モード設定,模式设置,模式設定


### PR DESCRIPTION
> **Note**
IntroPatchがCRLFだったので 2e35292b で先に改行コードを置換しています
実質的な差分は 2e35292b...2737a852 を参照してください

エアシップのマップ改造にオプションを追加しました

オプション名|デフォルト|説明
-|:-:|:-:
昇降機の上下の影を変更する|false
┣インポスターが下から上を見ることができる|true|インポスター視界の人視点で昇降機の下から上が見えるようにする
┗インポスター以外が上から下を見られなくする|false|インポスター視界ではない人視点で昇降機の上から下が見えないようにする

# スクリーンショット

インポスターが下から上を見ることができる
![image](https://github.com/SuperNewRoles/SuperNewRoles/assets/86903430/f3a9250b-11ef-447a-9f71-946baf61214c)

インポスター以外が上から下を見られない
![image](https://github.com/SuperNewRoles/SuperNewRoles/assets/86903430/ff2f990e-523b-4740-8b34-1e1380d6ba38)

