### PR TITLE
一部ビルド環境でSNRが読み込まれない問題を修正

### DIFF
--- a/SuperNewRoles/SuperNewRoles.csproj
+++ b/SuperNewRoles/SuperNewRoles.csproj
@@ -6,6 +6,7 @@
         <Authors>ykundesu</Authors>
         <AmongUs Condition=" '$(AmongUs)' == '' ">C:/Program Files/Epic Games/AmongUs_mymod</AmongUs>
         <langVersion>preview</langVersion>
+        <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
.NET8SDKにアップデートした環境でビルドを行うとSNRが読み込まれませんでした
原因等: BepInEx/BepInEx#708

# 再現

1. [.NET 8.0 SDK](https://dotnet.microsoft.com/ja-jp/download)をインストールし，SNRをビルドする
1. ビルドされたModを使用してAmongUsを起動する
1. 以下のログが出力され，SNRが読み込まれない
    ```text
    [Warning:   BepInEx] Skipping type [SuperNewRoles.SuperNewRolesPlugin] because its version is invalid.
    ```
