### PR TITLE
Feature/SHR mode role balancer

### DIFF
--- a/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
@@ -301,6 +301,8 @@ public static class SyncSetting
         IGameOptions optdata = OptionDatas[player].DeepCopy();
 
         optdata.SetBool(BoolOptionNames.AnonymousVotes, OpenVotes.VoteSyncSetting(player));
+        Balancer.InHostMode.SetMeetingSettings(optdata);
+
         if (player.AmOwner) GameManager.Instance.LogicOptions.SetGameOptions(optdata);
         else optdata.RpcSyncOption(player.GetClientId());
     }

--- a/SuperNewRoles/Patches/ChatHandlerPatch.cs
+++ b/SuperNewRoles/Patches/ChatHandlerPatch.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using BepInEx.Unity.IL2CPP.Utils.Collections;
 using HarmonyLib;
 using SuperNewRoles.Mode;
@@ -220,19 +221,25 @@ internal class AddChatPatch
             yield return new WaitForSeconds(time);
         }
         var crs = CustomRpcSender.Create("AllSend");
-        crs.AutoStartRpc(PlayerControl.LocalPlayer.NetId, (byte)RpcCalls.SetName)
+        var sender = PlayerControl.LocalPlayer;
+        if (sender.Data.IsDead)
+        {
+            sender = PlayerControl.AllPlayerControls.ToArray().Where(x => x != null && !x.Data.Disconnected && !x.Data.IsDead).OrderBy(x => x.PlayerId).FirstOrDefault();
+            name = sender.GetDefaultName();
+        }
+        crs.AutoStartRpc(sender.NetId, (byte)RpcCalls.SetName)
             .Write(SendName)
             .EndRpc()
-            .AutoStartRpc(PlayerControl.LocalPlayer.NetId, (byte)RpcCalls.SendChat)
+            .AutoStartRpc(sender.NetId, (byte)RpcCalls.SendChat)
             .Write(command)
             .EndRpc()
-            .AutoStartRpc(PlayerControl.LocalPlayer.NetId, (byte)RpcCalls.SetName)
+            .AutoStartRpc(sender.NetId, (byte)RpcCalls.SetName)
             .Write(name)
             .EndRpc()
             .SendMessage();
-        PlayerControl.LocalPlayer.SetName(SendName);
-        FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(PlayerControl.LocalPlayer, command);
-        PlayerControl.LocalPlayer.SetName(name);
+        sender.SetName(SendName);
+        FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sender, command);
+        sender.SetName(name);
     }
     static IEnumerator PrivateSend(PlayerControl target, string SendName, string command, float time = 0)
     {

--- a/SuperNewRoles/Patches/MeetingHudPatch.cs
+++ b/SuperNewRoles/Patches/MeetingHudPatch.cs
@@ -53,6 +53,9 @@ class CastVotePatch
             case RoleId.Crook:
                 IsValidVote = Crook.Ability.InHostMode.MeetingHudCastVote_Prefix(srcPlayerId, suspectPlayerId);
                 break;
+            case RoleId.Balancer:
+                IsValidVote = Balancer.InHostMode.MeetingHudCastVote_Prefix(srcPlayerId, suspectPlayerId);
+                break;
         }
 
         if (IsValidVote) // 有効票であれば,
@@ -800,6 +803,7 @@ class MeetingHudStartPatch
         if (PlayerControl.LocalPlayer.IsRole(RoleId.WiseMan)) WiseMan.StartMeeting();
         Knight.ProtectedPlayer = null;
         Knight.GuardedPlayers = new();
+        Balancer.InHostMode.StartMeeting();
         if (PlayerControl.LocalPlayer.IsRole(RoleId.Werewolf) && CachedPlayer.LocalPlayer.IsAlive() && !RoleClass.Werewolf.IsShooted)
         {
             CreateMeetingButton(__instance, "WerewolfKillButton", (int i, MeetingHud __instance) =>

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1514,6 +1514,15 @@ BalancerDoubleExileText,Both were exiled.,どちらも追放された。,二者�
 BalancerVoteTime,Votetime,天秤の投票時間,审判时间,阿努比斯的審判時間
 BalancerAbilityUseText,Ability activated,能力発動
 BalancerVoteText,Vote for one or the other!,どちらかに投票せよ！
+BalancerMeeting,Balancer Meeting,天秤会議,,
+BalancerSelection,Balancer Selection,天秤選択,,
+BalancerSelectionCancel,Cancel Balancer Selection,天秤選択解除,,
+BalancerSelectionCancelText,Balancer selection mode has been canceled.,天秤選択モードが解除されました,,
+BalancerSelectionText,Select by voting the two crew to send to the Balancer Meeting.*Skip to cancel balancer selection mode.,天秤にかける2人を投票によって選択してください\n※スキップで天秤選択モード解除,,
+Balancer1st,1st choice,1人目の選択,,
+Balancer2nd,2nd choice,2人目の選択,,
+BalancerForActivate,Vote yourself to activate the ability.,能力を発動するには自投票を行ってください,,
+BalancerUsed,Ability used. The ability cannot be activated.,能力使用済み 能力を発動することはできません,,
 PteranodonName,Pteranodon,プテラノドン,鸟人,無齒翼龍
 PteranodonTitle1,PtePte,プテプテ,一飞冲天啊，我,翼~翼~
 PteranodonButtonName,Juump!!,ジャーンプ！,飞跃,起飛！

--- a/SuperNewRoles/Roles/CrewMate/Balancer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Balancer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using AmongUs.GameOptions;
 using HarmonyLib;
 using Hazel;
 using SuperNewRoles.Helpers;
@@ -685,6 +686,21 @@ public static class Balancer
         {
             if (title != null && title != "") text = $"<size=100%><color=#ff8000>【{title}】</color></size>\n{text}";
             AddChatPatch.SendCommand(target, "", text);
+        }
+        public static void SetMeetingSettings(IGameOptions optdata)
+        {
+            if (!ModeHandler.IsMode(ModeId.SuperHostRoles)) return;
+
+            if (CurrentState == SHRBalancerState.BalancerMeeting)
+            {
+                optdata.SetInt(Int32OptionNames.DiscussionTime, 0);
+                optdata.SetInt(Int32OptionNames.VotingTime, (int)BalancerVoteTime.GetFloat());
+            }
+            else
+            {
+                optdata.SetInt(Int32OptionNames.DiscussionTime, GameOptionsManager.Instance.CurrentGameOptions.GetInt(Int32OptionNames.DiscussionTime));
+                optdata.SetInt(Int32OptionNames.VotingTime, GameOptionsManager.Instance.CurrentGameOptions.GetInt(Int32OptionNames.VotingTime));
+            }
         }
     }
     // ここにコードを書きこんでください

--- a/SuperNewRoles/Roles/CrewMate/Balancer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Balancer.cs
@@ -4,6 +4,7 @@ using HarmonyLib;
 using Hazel;
 using SuperNewRoles.Helpers;
 using SuperNewRoles.Mode;
+using SuperNewRoles.Patches;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
@@ -481,6 +482,11 @@ public static class Balancer
             currentAbilityUser = null;
             targetplayerleft = null;
             targetplayerright = null;
+        }
+        private static void SendChat(PlayerControl target, string text, string title = "")
+        {
+            if (title != null && title != "") text = $"<size=100%><color=#ff8000>【{title}】</color></size>\n{text}";
+            AddChatPatch.SendCommand(target, "", text);
         }
     }
     // ここにコードを書きこんでください

--- a/SuperNewRoles/Roles/CrewMate/Balancer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Balancer.cs
@@ -18,9 +18,9 @@ public static class Balancer
     public static CustomOption BalancerVoteTime;
     public static void SetupCustomOptions()
     {
-        BalancerOption = CustomOption.SetupCustomRoleOption(OptionId, false, RoleId.Balancer);
-        BalancerPlayerCount = CustomOption.Create(OptionId + 1, false, CustomOptionType.Crewmate, "SettingPlayerCountName", CustomOptionHolder.CrewPlayers[0], CustomOptionHolder.CrewPlayers[1], CustomOptionHolder.CrewPlayers[2], CustomOptionHolder.CrewPlayers[3], BalancerOption);
-        BalancerVoteTime = CustomOption.Create(OptionId + 2, false, CustomOptionType.Crewmate, "BalancerVoteTime", 30f, 0f, 180f, 2.5f, BalancerOption);
+        BalancerOption = CustomOption.SetupCustomRoleOption(OptionId, true, RoleId.Balancer);
+        BalancerPlayerCount = CustomOption.Create(OptionId + 1, true, CustomOptionType.Crewmate, "SettingPlayerCountName", CustomOptionHolder.CrewPlayers[0], CustomOptionHolder.CrewPlayers[1], CustomOptionHolder.CrewPlayers[2], CustomOptionHolder.CrewPlayers[3], BalancerOption);
+        BalancerVoteTime = CustomOption.Create(OptionId + 2, true, CustomOptionType.Crewmate, "BalancerVoteTime", 30f, 0f, 180f, 2.5f, BalancerOption);
     }
 
     public static List<PlayerControl> BalancerPlayer;

--- a/SuperNewRoles/Roles/CrewMate/Balancer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Balancer.cs
@@ -29,6 +29,10 @@ public static class Balancer
     public static bool IsAbilityUsed;
     public static void ClearAndReload()
     {
+        if (ModeHandler.IsMode(ModeId.SuperHostRoles))
+        {
+            InHostMode.ClearAndReload();
+        }
         BalancerPlayer = new();
         currentAbilityUser = null;
         CurrentState = BalancerState.NotBalance;
@@ -468,6 +472,16 @@ public static class Balancer
             BalancerMeeting,
         }
 
+        public static void ClearAndReload()
+        {
+            State.Clear();
+            NumOfBalance.Clear();
+
+            CurrentState = SHRBalancerState.NotBalance;
+            currentAbilityUser = null;
+            targetplayerleft = null;
+            targetplayerright = null;
+        }
     }
     // ここにコードを書きこんでください
 }

--- a/SuperNewRoles/Roles/CrewMate/Balancer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Balancer.cs
@@ -265,6 +265,10 @@ public static class Balancer
         currentAbilityUser = null;
         CurrentState = BalancerState.NotBalance;
         currentTarget = null;
+        if (ModeHandler.IsMode(ModeId.SuperHostRoles))
+        {
+            InHostMode.AfterMeetingTasks();
+        }
     }
     public static void StartAbility(PlayerControl source, PlayerControl player1, PlayerControl player2)
     {
@@ -660,6 +664,22 @@ public static class Balancer
             dispText = $"{decoration}\n{dispText}\n";
 
             SendChat(null, dispText);
+        }
+        public static void AfterMeetingTasks()
+        {
+            if (!ModeHandler.IsMode(ModeId.SuperHostRoles)) return;
+            if (!AmongUsClient.Instance.AmHost) return;
+
+            State.Clear();
+            Logger.Info($"AfterMeeting Clear", "Balancer.AfterMeetingTasks");
+
+            if (CurrentState != SHRBalancerState.BalancerMeeting) return;
+
+            CurrentState = SHRBalancerState.NotBalance;
+            currentAbilityUser = null;
+            targetplayerleft = null;
+            targetplayerright = null;
+            Logger.Info($"AfterBalancerMeeting Clear", "Balancer.AfterMeetingTasks");
         }
         private static void SendChat(PlayerControl target, string text, string title = "")
         {

--- a/SuperNewRoles/Roles/CrewMate/Balancer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Balancer.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using HarmonyLib;
 using Hazel;
 using SuperNewRoles.Helpers;
+using SuperNewRoles.Mode;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
@@ -61,6 +62,7 @@ public static class Balancer
     static float openMADENOtimer;
     public static void Update()
     {
+        if (ModeHandler.IsMode(ModeId.SuperHostRoles)) return;
         if (BackObject != null)
         {
             //切断したなら
@@ -237,6 +239,7 @@ public static class Balancer
     static string titletext => ModTranslation.GetString(ModHelpers.GetRandom(titletexts));
     static void SetActiveMeetingHud(bool active)
     {
+        if (ModeHandler.IsMode(ModeId.SuperHostRoles)) return;
         MeetingHud.Instance.TitleText.gameObject.SetActive(active);
         MeetingHud.Instance.TimerText.gameObject.SetActive(active);
         if (!active)
@@ -260,6 +263,7 @@ public static class Balancer
     }
     public static void StartAbility(PlayerControl source, PlayerControl player1, PlayerControl player2)
     {
+        if (ModeHandler.IsMode(ModeId.SuperHostRoles)) return;
         MeetingHud.Instance.discussionTimer = GameOptionsManager.Instance.CurrentGameOptions.GetInt(AmongUs.GameOptions.Int32OptionNames.VotingTime) - BalancerVoteTime.GetFloat() - 6.5f;
         currentAbilityUser = source;
         targetplayerleft = player1;
@@ -373,6 +377,7 @@ public static class Balancer
     {
         internal static void UpdateButtonsPostfix(MeetingHud __instance)
         {
+            if (ModeHandler.IsMode(ModeId.SuperHostRoles)) return;
             if (PlayerControl.LocalPlayer.IsDead())
             {
                 __instance.playerStates.ForEach(x => { if (x.transform.FindChild("BalancerButton") != null) Object.Destroy(x.transform.FindChild("SoothSayerButton").gameObject); });
@@ -393,6 +398,7 @@ public static class Balancer
         private static string nameData;
         static void BalancerOnClick(int Index, MeetingHud __instance)
         {
+            if (ModeHandler.IsMode(ModeId.SuperHostRoles)) return;
             if (currentAbilityUser != null) return;
             var Target = ModHelpers.PlayerById(__instance.playerStates[Index].TargetPlayerId);
             if (currentTarget == null)
@@ -412,6 +418,7 @@ public static class Balancer
         }
         static void Event(MeetingHud __instance)
         {
+            if (ModeHandler.IsMode(ModeId.SuperHostRoles)) return;
             if (PlayerControl.LocalPlayer.IsAlive() && !IsAbilityUsed)
             {
                 for (int i = 0; i < __instance.playerStates.Length; i++)
@@ -437,6 +444,7 @@ public static class Balancer
 
         internal static void MeetingHudStartPostfix(MeetingHud __instance)
         {
+            if (ModeHandler.IsMode(ModeId.SuperHostRoles)) return;
             Event(__instance);
         }
     }

--- a/SuperNewRoles/Roles/CrewMate/Balancer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Balancer.cs
@@ -448,5 +448,26 @@ public static class Balancer
             Event(__instance);
         }
     }
+    public static class InHostMode
+    {
+        private static Dictionary<byte, int> NumOfBalance = new();
+        private static Dictionary<byte, BalancerState> State = new();
+        private static int OptionNumOfBalance = 1;
+        private static SHRBalancerState CurrentState = SHRBalancerState.NotBalance;
+
+        private class BalancerState
+        {
+            public bool selecting = false;
+            public byte target1 = byte.MaxValue;
+            public byte target2 = byte.MaxValue;
+        }
+        enum SHRBalancerState
+        {
+            NotBalance,
+            ForBalancerMeeting,
+            BalancerMeeting,
+        }
+
+    }
     // ここにコードを書きこんでください
 }


### PR DESCRIPTION
役職 天秤のSHR対応

天秤
　会議中に２人を指名して、その２人のどちらかが必ず吊られる天秤会議を開くことができます。
　天秤会議では同数投票の場合はどちらも吊られます。
　天秤会議での対象２人以外への投票、無投票はランダムにどちらかへの投票になります。

SHR天秤会議の仕方
　１，自分に投票します
　　⇒天秤会議選択モードになり、操作方法がチャットに表示されます。
　２，ターゲット２人へ投票します
　　⇒その会議が終了し天秤会議が開かれます。
