### PR TITLE
イビルハッカーのサボタージュマップの色の調整

### DIFF
--- a/SuperNewRoles/Patches/MapPatch.cs
+++ b/SuperNewRoles/Patches/MapPatch.cs
@@ -96,7 +96,7 @@ public static class MapBehaviourPatch
             __instance.taskOverlay.Hide();
             __instance.HerePoint.enabled = true;
             PlayerControl.LocalPlayer.SetPlayerMaterialColors(__instance.HerePoint);
-            __instance.ColorControl.SetColor(Palette.ImpostorRed);
+            __instance.ColorControl.SetColor(new(0f, 0.73f, 1f));
             // アドミンがサボタージュとドア閉めのボタンに隠れないようにする
             // ボタンより手前
             __instance.countOverlay.transform.SetLocalZ(-3f);


### PR DESCRIPTION
イビルハッカーのオプション｢サボタージュマップにもアドミンを表示する｣有効時にサボタージュマップに重ねてアドミンを表示したときのマップ背景色を変更しました
赤背景だとインポスターの赤マークやドアの❌️マークが同化して見づらいみたいなので青色にしました
この色を選んだ理由は見分けやすさと目へのやさしさ以外特にないので変更可です
イビルハッカー以外のサボタージュマップ，｢サボタージュマップにもアドミンを表示する｣オプションオフ時のサボタージュマップには影響ありません

![image](https://github.com/SuperNewRoles/SuperNewRoles/assets/86903430/615803c3-341b-4483-9b23-0526241e1ff8)
