### PR TITLE
イビルハッカーに通信サボタージュ中にアドミンを使用できるオプションを追加

### DIFF
--- a/SuperNewRoles/MapOption/DeviceClass.cs
+++ b/SuperNewRoles/MapOption/DeviceClass.cs
@@ -102,8 +102,13 @@ public static class DeviceClass
                 if (IsChanging)
                     return false;
                 bool commsActive = false;
-                foreach (PlayerTask task in CachedPlayer.LocalPlayer.PlayerControl.myTasks)
-                    if (task.TaskType == TaskTypes.FixComms) commsActive = true;
+                if (!ShouldCountOverlayIgnoreComms())
+                {
+                    foreach (PlayerTask task in CachedPlayer.LocalPlayer.PlayerControl.myTasks)
+                    {
+                        if (task.TaskType == TaskTypes.FixComms) commsActive = true;
+                    }
+                }
 
                 if (!__instance.isSab && commsActive)
                 {

--- a/SuperNewRoles/MapOption/DeviceClass.cs
+++ b/SuperNewRoles/MapOption/DeviceClass.cs
@@ -302,6 +302,10 @@ public static class DeviceClass
             }
         }
     }
+    private static bool ShouldCountOverlayIgnoreComms()
+    {
+        return PlayerControl.LocalPlayer.IsRole(RoleId.EvilHacker) && EvilHacker.CanUseAdminDuringCommsSabotaged.GetBool();
+    }
     [HarmonyPatch(typeof(CounterArea), nameof(CounterArea.UpdateCount))]
     public static class CounterAreaUpdateCountPatch
     {

--- a/SuperNewRoles/MapOption/DeviceClass.cs
+++ b/SuperNewRoles/MapOption/DeviceClass.cs
@@ -80,9 +80,13 @@ public static class DeviceClass
     [HarmonyPatch(typeof(MapCountOverlay), nameof(MapCountOverlay.OnEnable))]
     class MapCountOverlayAwakePatch
     {
-        public static void Postfix()
+        public static void Postfix(MapCountOverlay __instance)
         {
             if (IsAdminRestrict && CachedPlayer.LocalPlayer.IsAlive() && !(PlayerControl.LocalPlayer.GetRoleBase<EvilHacker>()?.IsMyAdmin ?? false) && !BlackHatHacker.IsMyAdmin) AdminStartTime = DateTime.UtcNow;
+            if (ShouldCountOverlayIgnoreComms())
+            {
+                __instance.BackgroundColor.SetColor(Color.green);
+            }
         }
     }
     public static bool IsChanging = false;

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1092,6 +1092,7 @@ EvilHackerCanSeeDeadBodyPositions,Can See Dead-Body Positions,死体の位置が
 EvilHackerCanUseAdminDuringMeeting,Can Use Admin During Meeting,会議中にアドミンを使用できる,可以在会议中查看管理地图,駭客可以在會議中使用管理員地圖
 EvilHackerSabotageMapShowsAdmin,Sabotage Map Shows Admin,サボタージュマップにもアドミンを表示する,内鬼地图以管理地图的形式显示,駭客可以在破壞地圖中看到管理員地圖
 EvilHackerMapShowsDoorState,Map Shows Doors Status,マップにドアの開閉状況を表示する,地图上会显示门的开关情况,駭客可以在地圖中看到門的開關狀態
+EvilHackerCanUseAdminDuringCommsSabotaged,Can Use Admin During Comms Sabotaged,通信サボタージュ中にアドミンを使用できる
 CreateMadmateButton,Drive Mad,狂わせる,洗脑,洗腦
 CreateMadmateFastVerButton,Change of Heart,心変わりさせる,,變心
 PositionSwapperName,Position Swapper,ポジションスワッパー,念动使,交換使

--- a/SuperNewRoles/Roles/Impostor/EvilHacker.cs
+++ b/SuperNewRoles/Roles/Impostor/EvilHacker.cs
@@ -39,6 +39,7 @@ public class EvilHacker : RoleBase, IImpostor, ICustomButton
     public static CustomOption CanUseAdminDuringMeeting;
     public static CustomOption SabotageMapShowsAdmin;
     public static CustomOption MapShowsDoorState;
+    public static CustomOption CanUseAdminDuringCommsSabotaged;
 
     public CustomButtonInfo[] CustomButtonInfos { get; }
 
@@ -53,7 +54,7 @@ public class EvilHacker : RoleBase, IImpostor, ICustomButton
         CanUseAdminDuringMeeting = CustomOption.Create(Optioninfo.OptionId++, false, CustomOptionType.Impostor, "EvilHackerCanUseAdminDuringMeeting", true, Optioninfo.RoleOption);
         SabotageMapShowsAdmin = CustomOption.Create(Optioninfo.OptionId++, false, CustomOptionType.Impostor, "EvilHackerSabotageMapShowsAdmin", true, Optioninfo.RoleOption);
         MapShowsDoorState = CustomOption.Create(Optioninfo.OptionId++, false, CustomOptionType.Impostor, "EvilHackerMapShowsDoorState", true, Optioninfo.RoleOption);
-
+        CanUseAdminDuringCommsSabotaged = CustomOption.Create(Optioninfo.OptionId++, false, CustomOptionType.Impostor, "EvilHackerCanUseAdminDuringCommsSabotaged", true, Optioninfo.RoleOption);
     }
     public bool IsMyAdmin { get; set; }
     public bool CanCreateMadmate { get; private set; }


### PR DESCRIPTION
イビルハッカーにオプションを追加しました
"通信サボタージュ中にアドミンを使用できる",デフォルトtrue

他のロールでコミュサボを無視したくなったら`ShouldCountOverlayIgnoreComms`メソッドに条件を追加すると良いです
