### PR TITLE
ShareGameVersionPatchの処理の改善

### DIFF
--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -1200,7 +1200,9 @@ public static class RPCProcedure
             ver = new(major, minor, build);
         else
             ver = new(major, minor, build, revision);
-        ShareGameVersion.GameStartManagerUpdatePatch.VersionPlayers[clientId] = new PlayerVersion(ver, guid);
+
+        if (!ShareGameVersion.GameStartManagerUpdatePatch.VersionPlayers.TryGetValue(clientId, out PlayerVersion value) || !value.Equals(ver, guid))
+            ShareGameVersion.GameStartManagerUpdatePatch.VersionPlayers[clientId] = new PlayerVersion(ver, guid);
     }
     public static void SetRole(byte playerid, byte RPCRoleId)
     {


### PR DESCRIPTION
ModuleVersionId.ToByteArray()がかなり重いので、定数に変更しました。
併せて共通処理の関数化やPlayerVersionの更新を必要時のみにしたり細々とした改善も行っています。