### PR TITLE
翻訳関連のちょっとした修正

### DIFF
--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1298,6 +1298,7 @@ SluggerName,Slugger,スラッガー,击球手,擊球手
 SluggerTitle1,Lets’ Harisen Kill!,ハリセンでキルしよう,用全垒打把其他人击飞,用全壘打把其他人擊飛
 SluggerChargeTime,Charge Time,チャージ時間,击球手充能时间,擊球手充能時間
 SluggerIsMultiKill,Range kill possible,範囲キル可能,击球手可以大范围击杀,擊球手可以大範圍擊殺
+SluggerIsSyncKillCoolTime,Synchronize cool time with normal kills,通常キルとクールタイムを同期,冷却与通用击杀同步冷却,冷卻與通用擊殺同步冷卻
 SluggerButtonName,Harisen,ハリセン,挥棒,揮棒
 SatsumaAndImoName,SatsumaAndImo,さつまといも,人格分裂者,人格分裂者
 SatsumaAndImoTitle1,Madmate And Crewmate,マッドメイト & クルーメイト,是我疯了，还是大家都疯了？,是我瘋了，還是大家都瘋了？

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -214,10 +214,10 @@ IsYkundesuBeplnExSetting,ykundesuBeplnEx,ykundesuBeplnEx,启用ykundesuBeplnEx,y
 restrictOutOfTimeVerYkundesuBeplnEx,ykundesuBeplnEx IS! VERY! VERY DELICIOUSSSSS!!!!!，isn't it?,ﾖｯｷﾝｸﾞﾍﾞｯﾋﾟﾝｲｰｴｯｸｽおいしい,关注B站@心音糖果_Tingo谢谢喵！
 ReactorDurationSetting,Reactor Duration Time,緊急タスク継続時間の設定,自定义核反应堆紧急破坏持续时间,核子反應爐緊急任務持續時間
 SkeldReactorTime,The Skeld : reactor Duration Time,The Skeld : リアクターサボタージュの時間,骷髅舰(The  Skeld)核反应堆紧急破坏持续时间,The Skeld核子反應爐緊急任務持續時間
-SkeldLifeSuppTime,The Skeld : Oxygen Depleted Duration Time,<size=45%>The Skeld : 酸素枯渇までの時間</size>,骷髅舰(The Skeld)氧气紧急破坏持续时间,The Skeld氧氣枯竭緊急任務持續時間
+SkeldLifeSuppTime,The Skeld : Oxygen Depleted Duration Time,The Skeld : 酸素枯渇までの時間,骷髅舰(The Skeld)氧气紧急破坏持续时间,The Skeld氧氣枯竭緊急任務持續時間
 PolusReactorTime,Polus : Reset Stabilizers Duration Time,Polus : 耐震安定装置リセットの時間,波鲁斯(Polus)抗震器紧急破坏持续时间,Polus核子反應爐震盪緊急任務持續時間
 MiraReactorTime,MiraHQ : reactor Duration Time,MiraHQ : リアクターサボタージュの時間,米拉总部(Mira)核反应堆紧急破坏持续时间,MiraHQ核子反應爐緊急任務持續時間
-MiraLifeSuppTime,MiraHQ : Oxygen Depleted Duration Time,<size=50%>MiraHQ : 酸素枯渇までの時間</size>,米拉总部(Mira)氧气紧急破坏持续时间,MiraHQ氧氣枯竭緊急任務持續時間
+MiraLifeSuppTime,MiraHQ : Oxygen Depleted Duration Time,MiraHQ : 酸素枯渇までの時間,米拉总部(Mira)氧气紧急破坏持续时间,MiraHQ氧氣枯竭緊急任務持續時間
 AirshipReactorTime,Airship : Avert Cresh Course Duration Time,AirShip : 衝突回避の時間,飞艇(AirShip)撞毁路线紧急破坏持续时间,AirShip飛船撞毀緊急任務持續時間
 FungleReactorTime,The Fungle : reactor Duration Time,The Fungle : リアクターサボタージュの時間,蘑菇岛(The Fungle)核反应堆破坏紧急持续时间,The Fungle核子反應爐緊急任務持續時間
 VentMakerButtonName,Make Vent,設置,制造管道口,製造通風管道出入口


### PR DESCRIPTION
・「SluggerIsSyncKillCoolTime」の翻訳漏れ
・「酸素枯渇までの時間」がなぜか小さく表示される
以上2点を修正しました。