### PR TITLE
ModHelpers.Csの改良

### DIFF
--- a/SuperNewRoles/ModHelpers.cs
+++ b/SuperNewRoles/ModHelpers.cs
@@ -944,7 +944,12 @@ public static class ModHelpers
 
     public static string Cs(Color c, string s)
     {
-        return string.Format("<color=#{0:X2}{1:X2}{2:X2}{3:X2}>{4}</color>", CustomOptionHolder.ToByte(c.r), CustomOptionHolder.ToByte(c.g), CustomOptionHolder.ToByte(c.b), CustomOptionHolder.ToByte(c.a), s);
+        return $"<color=#{ToByte(c.r):X2}{ToByte(c.g):X2}{ToByte(c.b):X2}{ToByte(c.b):X2}>{s}</color>";
+    }
+    public static byte ToByte(float f)
+    {
+        f = Mathf.Clamp01(f);
+        return (byte)(f * 255);
     }
     public static T GetRandom<T>(this Il2CppSystem.Collections.Generic.List<T> list)
     {

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -932,14 +932,7 @@ public class CustomOptionHolder
 
     public static string Cs(Color c, string s)
     {
-        return string.Format("<color=#{0:X2}{1:X2}{2:X2}{3:X2}>{4}</color>", ToByte(c.r), ToByte(c.g), ToByte(c.b), ToByte(c.a), ModTranslation.GetString(s));
-    }
-
-
-    public static byte ToByte(float f)
-    {
-        f = Mathf.Clamp01(f);
-        return (byte)(f * 255);
+        return ModHelpers.Cs(c, ModTranslation.GetString(s));
     }
 
     public static void Load()

--- a/SuperNewRoles/Patches/ProtectPatch.cs
+++ b/SuperNewRoles/Patches/ProtectPatch.cs
@@ -131,7 +131,7 @@ static class CheckProtectPatch
         }
 
         Color roleColor = angelRole != RoleId.DefaultRole ? CustomRoles.GetRoleColor(angelRole) : CustomRoles.GetRoleColor(angel.GetRole());
-        string colorCode = string.Format($"#{CustomOptionHolder.ToByte(roleColor.r):X2}{CustomOptionHolder.ToByte(roleColor.g):X2}{CustomOptionHolder.ToByte(roleColor.b):X2}{CustomOptionHolder.ToByte(roleColor.a):X2}");
+        string colorCode = $"#{ModHelpers.ToByte(roleColor.r):X2}{ModHelpers.ToByte(roleColor.g):X2}{ModHelpers.ToByte(roleColor.b):X2}{ModHelpers.ToByte(roleColor.a):X2}";
 
         return (announceBuilder.ToString(), colorCode);
     }


### PR DESCRIPTION
string.Formatから補間文字列に変更しました。
.NET 6からコンパイラで最適化が入るはずなので、パフォーマンス的にはこちらの方がよいかと。
また、CustomOptionHolder.cs内のCsもModHelpersの実装を使うように変更しました。ToByteもModHelpersにある方が適切と思ったのでそちらに移動してあります。