### PR TITLE
GetPlayerControlをリファクタリング

### DIFF
--- a/SuperNewRoles/ModHelpers.cs
+++ b/SuperNewRoles/ModHelpers.cs
@@ -1057,15 +1057,12 @@ public static class ModHelpers
     public static PlayerControl PlayerById(byte id)
     {
         if (!IdControlDic.ContainsKey(id))
-        { // idが辞書にない場合全プレイヤー分のループを回し、辞書に追加する
-            foreach (PlayerControl pc in CachedPlayer.AllPlayers)
-            {
-                if (!IdControlDic.ContainsKey(pc.PlayerId)) // Key重複対策
-                    IdControlDic.Add(pc.PlayerId, pc);
-            }
+        { // idが辞書にない場合、プレイヤー情報を辞書に追加する
+            PlayerControl cachedPlayer = CachedPlayer.AllPlayers.Find(x => x.PlayerId == id);
+            if (cachedPlayer != null) IdControlDic.Add(id, cachedPlayer);
         }
         if (IdControlDic.ContainsKey(id)) return IdControlDic[id];
-        Logger.Error($"idと合致するPlayerIdが見つかりませんでした。nullを返却します。id:{id}", "ModHelpers");
+        Logger.Info($"idと合致するPlayerIdが見つかりませんでした。nullを返却します。id:{id}", "ModHelpers");
         return null;
     }
     public static Vent VentById(byte id)


### PR DESCRIPTION
1.ログメッセージの修正

挙動確認した時に、
以下のようなエラーメッセージが表示されることが気になったので、
修正及びリファクタリングしています。

`[Error  :SuperNewRoles] [15:32:13.667][PlayerById][ModHelpers]idと合致するPlayerIdが見つかりませんでした。nullを返却します。id:255`


2.ユーザー情報をループして取得していたのを修正
プレイヤー数が多くなればなるほど倍々と重くなっている要素だったので修正しています。
(ループでHitしたら脱出するようにしても良いかもですが、findとかで見つけた方が軽いと判断しています。)

自環境では軽くなったか比較できないので効果を感じるかは不明です。



x.その他
public static Vent VentById(byte id)のメソッドも同様な改善が出来ると思います。(そこに限らずですが、foreachでのループを多用しているようなので、各所改善見込めそうです)