### PR TITLE
2つの未翻訳を修正・未翻訳が見つかった際、ログを出力するように

### DIFF
--- a/SuperNewRoles/ModTranslation.cs
+++ b/SuperNewRoles/ModTranslation.cs
@@ -222,7 +222,12 @@ internal unsafe struct FastHashTable
         var keyBytes = Encoding.UTF8.GetBytes(key);
         fixed (byte* keyPtr = keyBytes)
         {
-            return GetRaw(keyPtr, keyBytes.Length) ?? key;
+            string value = GetRaw(keyPtr, keyBytes.Length);
+            if (value == null)
+            { // keyがCSVにない場合にログを出力
+                Logger.Warning($"Missing translation for key: {key}");
+            }
+            return value ?? key;
         }
     }
 

--- a/SuperNewRoles/Resources/TranslationData.csv
+++ b/SuperNewRoles/Resources/TranslationData.csv
@@ -912,6 +912,8 @@ WaveCannonJackalBulletLoadBulletCooltime,装填クールタイム,Bullet Charge 
 WaveCannonJackalBulletLoadedChargeTime,超波動砲のチャージ時間,Bullet Loaded Charge Time,子弹充能时间,子彈充能時間
 WaveCannonJackalCreateBulletToJackal,弾がジャッカルに昇格する,Bullet becomes Jackal,子弹成为杰克,子彈成為傑克
 WaveCannonJackalNewJackalHaveWaveCannon,弾が昇格した際波動砲を持つ,Bullet becomes Jackal and has Wave Cannon,子弹成为杰克并拥有波动炮,子彈成為傑克並擁有波動砲
+WaveCannonJackalBulletCanSeeParent,弾が主人をわかる,Bullet recognizes its owner
+WaveCannonJackalCanSeeBullet,ジャッカルが弾をわかる,Jackal recognizes the bullet
 BulletEmergencyText,なんだか怖くて会議を開けない...,Something is scary and I can't open the meeting...,什么东西很可怕，我开不了会...,什麼東西很可怕，我開不了會...
 BulletButton,装填,Load,装填,裝填
 


### PR DESCRIPTION
**2つの未翻訳を修正**
 - "WaveCannonJackalBulletCanSeeParent"と"WaveCannonJackalCanSeeBullet"の未翻訳を修正。

**未翻訳が見つかった際、ログを出力するように**
 - ModTranslationのGetメソッド内において、keyがCSVになかった場合にログを出力するように。
 - ログのレベルはWarningです。
<img width="708" height="73" alt="image" src="https://github.com/user-attachments/assets/9329591e-2775-4cc2-a2d3-e0a39e811c42" />
<img width="408" height="287" alt="image" src="https://github.com/user-attachments/assets/1a4e8439-b6cf-4a6f-b6af-b5e689a64576" />
