### PR TITLE
会議後にアビリティボタンのタイマー色が緑のままになるバグを修正

### DIFF
--- a/SuperNewRoles/Roles/Ability/CustomButton/CustomButtonBase.cs
+++ b/SuperNewRoles/Roles/Ability/CustomButton/CustomButtonBase.cs
@@ -300,6 +300,10 @@ public abstract class CustomButtonBase : AbilityBase
             buttonEffect.EffectTimer = buttonEffect.EffectDuration;
             buttonEffect.isEffectActive = false;
         }
+        if (actionButton != null)
+        { // タイマーテキストの色をデフォルトに戻し、会議後などに色が緑のまま残ることを防ぐ。
+            actionButton.cooldownTimerText.color = Palette.EnabledColor;
+        }
     }
     public override void DetachToLocalPlayer()
     {


### PR DESCRIPTION
### 概要

波動砲・ホークなどのチャージ系・持続系アビリティを使用中に会議が始まると、会議終了後にクールダウンタイマーのテキスト色が緑のままになってしまうUIの不具合を修正しました。

### 変更点

*   **原因:**
    会議終了時にアビリティのタイマー自体はリセットされていましたが、タイマーテキストの色をデフォルト（白色）に戻す処理が欠けていました。
*   **修正内容:**
    すべてのアビリティボタンの基底クラスである `CustomButtonBase.cs` の `ResetTimer` メソッドに、タイマーテキストの色を `Palette.EnabledColor` にリセットする処理を追加しました。

*   この修正は `IButtonEffect` インターフェースを実装するすべてのチャージ系アビリティに適用されます。

**そのほかに特別な実装がある役職について確認が漏れている場合は、お手数ですがコメントにてご指摘ください。**