### PR TITLE
役職辞典の表示制御機能を追加・スラッガーが役職辞典に表示される問題を修正

### DIFF
--- a/SuperNewRoles/HelpMenus/MenuCategories/RoleDictionaryHelpMenu.cs
+++ b/SuperNewRoles/HelpMenus/MenuCategories/RoleDictionaryHelpMenu.cs
@@ -156,7 +156,7 @@ public class RoleDictionaryHelpMenu : HelpMenuCategoryBase
 
         // 役職一覧を取得
         var roles = CustomRoleManager.AllRoles
-            .Where(r => r.QuoteMod != QuoteMod.Vanilla && (r.OptionTeam == teamType || (r.OptionTeam == RoleOptionMenuType.Hidden && r.AssignedTeam == (AssignedTeamType)teamType)))
+            .Where(r => r.QuoteMod != QuoteMod.Vanilla && !r.HideInRoleDictionary && (r.OptionTeam == teamType || (r.OptionTeam == RoleOptionMenuType.Hidden && r.AssignedTeam == (AssignedTeamType)teamType)))
             .OrderBy(r => r.Role.ToString())
             .Where(r => r.Role != RoleId.Vampire && r.Role != RoleId.VampireDependent)
             .ToList();

--- a/SuperNewRoles/HelpMenus/MenuCategories/RoleDictionaryHelpMenu.cs
+++ b/SuperNewRoles/HelpMenus/MenuCategories/RoleDictionaryHelpMenu.cs
@@ -158,7 +158,6 @@ public class RoleDictionaryHelpMenu : HelpMenuCategoryBase
         var roles = CustomRoleManager.AllRoles
             .Where(r => r.QuoteMod != QuoteMod.Vanilla && !r.HideInRoleDictionary && (r.OptionTeam == teamType || (r.OptionTeam == RoleOptionMenuType.Hidden && r.AssignedTeam == (AssignedTeamType)teamType)))
             .OrderBy(r => r.Role.ToString())
-            .Where(r => r.Role != RoleId.Vampire && r.Role != RoleId.VampireDependent)
             .ToList();
 
         // ボタンの配置設定

--- a/SuperNewRoles/Roles/Impostor/Slugger.cs
+++ b/SuperNewRoles/Roles/Impostor/Slugger.cs
@@ -25,6 +25,7 @@ class Slugger : RoleBase<Slugger>
     public override RoleTag[] RoleTags => [RoleTag.SpecialKiller, RoleTag.Killer];
     public override short IntroNum => 1;
     public override RoleOptionMenuType OptionTeam => RoleOptionMenuType.Hidden;
+    public override bool HideInRoleDictionary => true; // 役職辞典で非表示にする
 
     [CustomOptionFloat("SluggerChargeTime", 0.5f, 10f, 0.5f, 3f, translationName: "DurationTime")]
     public static float SluggerChargeTime;

--- a/SuperNewRoles/Roles/Impostor/Vampire.cs
+++ b/SuperNewRoles/Roles/Impostor/Vampire.cs
@@ -46,6 +46,7 @@ class Vampire : RoleBase<Vampire>
     public override TeamTag TeamTag => TeamTag.Impostor;
     public override RoleTag[] RoleTags => new RoleTag[] { RoleTag.SpecialKiller };
     public override RoleOptionMenuType OptionTeam => RoleOptionMenuType.Hidden;
+    public override bool HideInRoleDictionary => true; // 役職辞典で非表示にする
 
     [CustomOptionFloat("VampireAbsorptionCooldown", 2.5f, 60f, 2.5f, 30f)]
     public static float VampireAbsorptionCooldown;

--- a/SuperNewRoles/Roles/Impostor/VampireDependent.cs
+++ b/SuperNewRoles/Roles/Impostor/VampireDependent.cs
@@ -9,6 +9,7 @@ using SuperNewRoles.Modules.Events.Bases;
 using SuperNewRoles.Events.PCEvents;
 
 namespace SuperNewRoles.Roles.Impostor;
+
 class VampireDependent : RoleBase<VampireDependent>
 {
     public override RoleId Role => RoleId.VampireDependent;
@@ -36,6 +37,7 @@ class VampireDependent : RoleBase<VampireDependent>
     public override TeamTag TeamTag => TeamTag.Impostor;
     public override RoleTag[] RoleTags => [RoleTag.ImpostorTeam];
     public override RoleOptionMenuType OptionTeam => RoleOptionMenuType.Hidden;
+    public override bool HideInRoleDictionary => true; // 役職辞典で非表示にする
 }
 public record VampireDependentData(float killCooldown, bool canUseVent);
 public class VampireDependentAbility : AbilityBase

--- a/SuperNewRoles/Roles/RoleBase.cs
+++ b/SuperNewRoles/Roles/RoleBase.cs
@@ -54,6 +54,7 @@ internal abstract class RoleBase<T> : BaseSingleton<T>, IRoleBase where T : Role
 
     public abstract RoleOptionMenuType OptionTeam { get; }
     public virtual MapNames[] AvailableMaps { get; } = [];
+    public virtual bool HideInRoleDictionary => false;
 
     // public abstract void CreateCustomOption();
 }
@@ -85,6 +86,8 @@ public interface IRoleBase : IRoleInformation
 
     public RoleId[] RelatedRoleIds { get; }
     public MapNames[] AvailableMaps { get; }
+    public bool HideInRoleDictionary { get; }
+
     /// <summary>
     /// AbilityはAbilitiesから自動でセットされるが、追加で他の処理を行いたい場合はOverrideすること
     /// </summary>


### PR DESCRIPTION
### 説明
このPRは、特定の役職を役職辞典 (`RoleDictionary`) から非表示にする機能を追加します。
`Slugger`、`Vampire`、`VampireDependent` を非表示に設定しました。

#### 変更点
- **`RoleBase.cs` の拡張**
  - `IRoleBase` に `HideInRoleDictionary` プロパティを追加しました。
  - 各役職クラスでこのプロパティをオーバーライドすることで、役職辞典での表示・非表示を個別に制御できます。（デフォルトは表示）
- **対象役職の更新**
  - `Slugger`, `Vampire`, `VampireDependent` の `HideInRoleDictionary` を `true` に設定し、非表示にしました。
- **役職辞典のロジック修正**
  - `RoleDictionaryHelpMenu.cs` を修正し、`HideInRoleDictionary` が `true` の役職を除外するようにしました。
  - これにより、特定の役職名をハードコードで除外していた処理を削除し、より汎用的で保守性の高い実装になりました。

#### 目的
- 役職辞典の情報を整理し、プレイヤーにとってより分かりやすくする。
- 今後、他の役職を非表示にしたい場合に、各役職ファイルで簡単に設定変更できるようにする。