### PR TITLE
パン屋のレアテキストの翻訳と確率を修正

### DIFF
--- a/SuperNewRoles/Resources/TranslationData.csv
+++ b/SuperNewRoles/Resources/TranslationData.csv
@@ -1263,7 +1263,7 @@ MirageLimitCount,使用可能回数,Max Uses,最大使用次数,最大使用次�
 
 # Bakery
 BakeryExileText,パン屋がパンを焼いたようだ...,Bakery baked bread,面包屋烤了面包,麵包屋烤了麵包
-BakeryExileText2,パン屋がパンを焼いたようだ...,Bakery baked bread,面包屋烤了面包,麵包屋烤了麵包
+BakeryExileText2,パン屋ｧｧﾉｫｫﾖｯｷﾝｸﾞﾍﾞｯﾋﾟﾝｲｰｴｰｴｯｸｽｵｲｼｲ,Bakery baked YOKINGDELICIOUSSSSSSSSS!!!!,面硬加咸蔬菜加倍蒜末和油多多！（快住手，这根本不是面包）,麵包夾蛋加蔥末再加新鮮的麵包師傅！
 
 # MadRaccoon
 MadRaccoonShapeshiftCooldown,シェイプシフトクールダウン,MadRaccoon Shapeshift Cooldown,變身冷卻時間

--- a/SuperNewRoles/Roles/CrewMate/Bakery.cs
+++ b/SuperNewRoles/Roles/CrewMate/Bakery.cs
@@ -39,7 +39,8 @@ public class BakeryAbility : AbilityBase
         get
         {
             var rand = new System.Random();
-            return rand.Next(1, 10) == 1 ? ModTranslation.GetString("BakeryExileText2") : ModTranslation.GetString("BakeryExileText");
+            // System.Random.NextのmaxValueはexclusive(排他的)なので、1から10の値を得るためには1と11を指定する
+            return rand.Next(1, 11) == 1 ? ModTranslation.GetString("BakeryExileText2") : ModTranslation.GetString("BakeryExileText");
         }
     }
     public override void AttachToAlls()


### PR DESCRIPTION
### 説明
 - パン屋のレアテキストの翻訳(`BakeryExileText`)が通常テキストと(`BakeryExileText2`)と同じになっていたため、レアテキストが出ていなかった問題を修正。
 - レアテキストの確率が９分の１になっていた問題を修正。(wikiには10％との記載)

### 補足
 - 翻訳はv2.7.0.2から戻してきています。
 - 詳細はDiscord Ticket0448