### PR TITLE
一部UIの未翻訳を修正

### DIFF
--- a/SuperNewRoles/CustomOptions/ExclusivityOptionMenu.cs
+++ b/SuperNewRoles/CustomOptions/ExclusivityOptionMenu.cs
@@ -113,6 +113,7 @@ public static class ExclusivityOptionMenu
     private static void ConfigureEditButton(GameObject button, int index)
     {
         var editButton = button.transform.Find("EditButton").gameObject;
+        UIHelper.SetText(editButton, ModTranslation.GetString("ExclusivityEditText"));
         var passiveButton = editButton.AddComponent<PassiveButton>();
         passiveButton.Colliders = new Collider2D[] { editButton.GetComponent<BoxCollider2D>() };
         var spriteRenderer = editButton.transform.Find("Background").GetComponent<SpriteRenderer>();

--- a/SuperNewRoles/Modules/VersionUpdates.cs
+++ b/SuperNewRoles/Modules/VersionUpdates.cs
@@ -45,6 +45,13 @@ public static class VersionUpdatesUI
     public static void InitializeMainMenuButton(MainMenuManager __instance)
     {
         GameObject versionSelectButton = AssetManager.Instantiate(VersionSelectButtonPrefab, null);
+
+        var buttonText = versionSelectButton.transform.Find("Text")?.GetComponent<TextMeshPro>();
+        if (buttonText != null)
+        {
+            buttonText.text = ModTranslation.GetString("VersionSelectButtonText");
+        }
+
         versionSelectButton.transform.localPosition = Vector3.zero;
         versionSelectButton.transform.localScale = Vector3.one * VersionSelectButtonScale;
         PassiveButton passiveButton = versionSelectButton.AddComponent<PassiveButton>();

--- a/SuperNewRoles/Modules/VersionUpdates.cs
+++ b/SuperNewRoles/Modules/VersionUpdates.cs
@@ -79,6 +79,13 @@ public static class VersionUpdatesUI
         versionContainer.transform.localScale = Vector3.one;
         versionContainer.transform.localRotation = Quaternion.identity;
 
+        var titleText = versionContainer.transform.Find("AutoUpDateModeSelecter/UITextGrayBack/Text")?.GetComponent<TextMeshPro>();
+        if (titleText != null)
+        {
+            // 翻訳キーを使ってテキストを設定
+            titleText.text = ModTranslation.GetString("VersionUpdateAutoText");
+        }
+
         GameObject updateTypeButton = versionContainer.transform.Find("AutoUpDateModeSelecter/UpdateTypeBox").gameObject;
         ConfigureUpdateTypeButton(updateTypeButton);
 
@@ -113,6 +120,7 @@ public static class VersionUpdatesUI
         closeButtonPassiveButton.OnClick.AddListener((UnityAction)(() => fadeCoroutine.StartFadeOut(versionSelect, FadeDuration, true)));
         closeButtonPassiveButton.OnMouseOver = new();
         closeButtonPassiveButton.OnMouseOut = new();
+        ModHelpers.LogHierarchy(versionContainer.transform);
     }
     public static void ConfigureVersionListScroller(GameObject versionListScroller)
     {

--- a/SuperNewRoles/Modules/VersionUpdates.cs
+++ b/SuperNewRoles/Modules/VersionUpdates.cs
@@ -120,7 +120,6 @@ public static class VersionUpdatesUI
         closeButtonPassiveButton.OnClick.AddListener((UnityAction)(() => fadeCoroutine.StartFadeOut(versionSelect, FadeDuration, true)));
         closeButtonPassiveButton.OnMouseOver = new();
         closeButtonPassiveButton.OnMouseOut = new();
-        ModHelpers.LogHierarchy(versionContainer.transform);
     }
     public static void ConfigureVersionListScroller(GameObject versionListScroller)
     {

--- a/SuperNewRoles/Modules/VersionUpdates.cs
+++ b/SuperNewRoles/Modules/VersionUpdates.cs
@@ -82,7 +82,6 @@ public static class VersionUpdatesUI
         var titleText = versionContainer.transform.Find("AutoUpDateModeSelecter/UITextGrayBack/Text")?.GetComponent<TextMeshPro>();
         if (titleText != null)
         {
-            // 翻訳キーを使ってテキストを設定
             titleText.text = ModTranslation.GetString("VersionUpdateAutoText");
         }
 

--- a/SuperNewRoles/Resources/TranslationData.csv
+++ b/SuperNewRoles/Resources/TranslationData.csv
@@ -274,6 +274,7 @@ DisplayText.CanNotUseSHR,未実装,Not implemented.,未实施,未實施
 ModeId.BattleRoyal,バトルロイヤル,Battle Royale,戰鬥皇家,戰鬥皇家
 ModeOption,モード,Mode,模式,模式
 ExclusivityOptionMenuTitle,排他設定,Exclusivity Settings,排他設定,排他設定
+ExclusivityEditText,編集,Edit
 ExclusivityOptionMenuMaxText,最大排出数,Max Exclusivity,最大排出數,最大排出數
 ExclusivityOptionMenuAssignedRoleText,割当役職,Assigned Role,指派職位,指派職位
 ExclusivityOptionMenuGroupText,グループ {0},Group {0},群組 {0},群組 {0}

--- a/SuperNewRoles/Resources/TranslationData.csv
+++ b/SuperNewRoles/Resources/TranslationData.csv
@@ -167,6 +167,7 @@ ClientOptionsMod,Mod設定,Mod Settings,模组设置,模組設置
 Winners.NoData,データがありません,No data,没有数据,沒有數據
 
 # VersionUpdates
+VersionSelectButtonText,バージョン変更,Change Version
 VersionUpdateType.stability,安定版,Stability,稳定版,穩定版
 VersionUpdateType.all,全て,All,全部,全部
 VersionUpdateType.static,固定,Static,固定版,固定版

--- a/SuperNewRoles/Resources/TranslationData.csv
+++ b/SuperNewRoles/Resources/TranslationData.csv
@@ -169,6 +169,12 @@ Winners.NoData,データがありません,No data,没有数据,沒有數據
 # VersionUpdates
 VersionSelectButtonText,バージョン変更,Change Version
 VersionUpdateAutoText,自動アップデート,Automatic Updates
+VersionUpdateType.stability,安定版,Stability,稳定版,穩定版
+VersionUpdateType.all,全て,All,全部,全部
+VersionUpdateType.static,固定,Static,固定版,固定版
+VersionUpdateType.disable,無効,Disable,禁用,禁用
+VersionUpdateLoading,バージョンリストを取得中...,Loading version list...
+VersionUpdateGet,変更,Change,變更,變更
 VersionCurrent,選択中,Current,選擇中,選擇中
 VersionWillUpdate,再起動後適用,Apply after restart
 VersionLoaded,適用済み,Applied,已適用,已適用

--- a/SuperNewRoles/Resources/TranslationData.csv
+++ b/SuperNewRoles/Resources/TranslationData.csv
@@ -168,12 +168,7 @@ Winners.NoData,データがありません,No data,没有数据,沒有數據
 
 # VersionUpdates
 VersionSelectButtonText,バージョン変更,Change Version
-VersionUpdateType.stability,安定版,Stability,稳定版,穩定版
-VersionUpdateType.all,全て,All,全部,全部
-VersionUpdateType.static,固定,Static,固定版,固定版
-VersionUpdateType.disable,無効,Disable,禁用,禁用
-VersionUpdateLoading,バージョンリストを取得中...,Loading version list...
-VersionUpdateGet,変更,Change,變更,變更
+VersionUpdateAutoText,自動アップデート,Automatic Updates
 VersionCurrent,選択中,Current,選擇中,選擇中
 VersionWillUpdate,再起動後適用,Apply after restart
 VersionLoaded,適用済み,Applied,已適用,已適用


### PR DESCRIPTION
いくつかの画面でUIテキストが翻訳されず、常に日本語で表示される問題を修正しました。

#### 修正点

-   メインメニューの「バージョン変更」ボタン
-   バージョン変更画面の「自動アップデート」ラベル
-   排他設定画面の「編集」ボタン

#### 修正の背景

これらのテキストは、各UIのプレハブに直接書き込まれており（ハードコード）、翻訳システム (`ModTranslation`) を経由していませんでした。
そのため、どの言語設定でゲームを起動しても、プレハブに設定された日本語のテキストがそのまま表示されていました。

#### 変更内容

各UI要素を初期化する処理において、`ModTranslation.GetString()` を使って翻訳キーからテキストを動的に設定するようにコードを追加しました。

-   **VersionUpdatesUI.cs**: `InitializeMainMenuButton` と `ShowVersionSelect` 内で、ボタンとラベルのテキストを設定する処理を追加。
-   **ExclusivityOptionMenu.cs**: `ConfigureEditButton` 内で、ボタンのテキストを設定する処理を追加。

これにより、言語設定に応じてテキストが正しく表示されるようになります。

ご確認のほど、よろしくお願いいたします。
